### PR TITLE
switch the order of mtllib usemtl

### DIFF
--- a/tools/vol2obj/main.c
+++ b/tools/vol2obj/main.c
@@ -231,8 +231,8 @@ static bool _write_mesh_to_obj_file( const char* output_mesh_filename, const cha
 
   fprintf( f_ptr, "#Exported by Volograms vols2obj\n" );
   if ( output_mtl_filename ) {
+    fprintf( f_ptr, "mtllib %s\n", output_mtl_filename ); // mtllib must go before usemtl or some viewers won't load the texture.
     fprintf( f_ptr, "usemtl %s\n", material_name );
-    fprintf( f_ptr, "mtllib %s\n", output_mtl_filename );
   }
 
   assert( vertices_ptr && "Hey if there are no vertex points Anton should make sure that is accounted for in the f section" );


### PR DESCRIPTION
Reason for PR

* Windows 3D viewer didn't display with texture.
* This is because the order of usemtl and mtllib needs to be the other way around in the obj file.
* Other viewers don't have this issue.

Changes in PR

* Switched the order of those two instructions.

Testing Summary

* Tested with a new (gold standard) vologram in Windows 3d viewer (pictured).
* Tested the same obj in Blender to check for regression there.

Risk of Merging PR

* negligible

![image](https://user-images.githubusercontent.com/1935602/153230187-d666da07-0972-41cf-a315-55adef9eef4d.png)
![image](https://user-images.githubusercontent.com/1935602/153230541-a2febe60-0fdb-43b5-97b2-264e51c04770.png)
