### PR TITLE
drag and drop directory support

### DIFF
--- a/tools/vol2obj/main.c
+++ b/tools/vol2obj/main.c
@@ -486,7 +486,30 @@ int main( int argc, char** argv ) {
   int last_frame  = 0;
   bool all_frames = false;
 
-  { // command line parameters
+  // paths for drag-and-drop directory
+  char dad_hdr_str[2048], dad_seq_str[2048], dad_vid_str[2048];
+  dad_hdr_str[0] = dad_seq_str[0] = dad_vid_str[0] = '\0';
+
+  // check for drag-and-drop directory
+  if ( 2 == argc && _does_dir_exist( argv[1] ) ) {
+    int len = strlen( argv[1] );
+    strncat( dad_hdr_str, argv[1], 2047 );
+    strncat( dad_seq_str, argv[1], 2047 );
+    strncat( dad_vid_str, argv[1], 2047 );
+    if ( argv[1][len - 1] != '\\' && argv[1][len - 1] != '/' ) {
+      strncat( dad_hdr_str, "/", 2047 );
+      strncat( dad_seq_str, "/", 2047 );
+      strncat( dad_vid_str, "/", 2047 );
+    }
+    strncat( dad_hdr_str, "header.vols", 2047 );
+    strncat( dad_seq_str, "sequence_0.vols", 2047 );
+    strncat( dad_vid_str, "texture_2048_h264.mp4", 2047 );
+    _input_header_filename   = dad_hdr_str;
+    _input_sequence_filename = dad_seq_str;
+    _input_video_filename    = dad_vid_str;
+  } else {
+    // regular command line parameters
+
     my_argc = argc;
     my_argv = argv;
     if ( _check_param( "--all" ) ) { all_frames = true; }


### PR DESCRIPTION
Reason for PR

* specifying header, sequence, texture separately is quite tedious (but sometimes useful, where >1 texture video file exists).
* not everyone who wants to use the tool knows how to use a terminal/command line.
* so this PR adds an option to drag a folder onto the binary and have it look for default file Volu names (with 2k video texture) within that folder
* e.g. just drag your vologram folder onto the vol2obj.exe file
* limitation - it doesn't know which frames you want so it just spits out the first frame at the moment. so handy for a quick preview.

Changes in PR

* if there is only one command line arg, the program checks if it's a valid directory, and if so goes with drag-and-drop option instead of normal usage.
* because no frame range is specified in this case then it just spits out the first frame as an obj+texture+material. so handy for a quick preview.
* you can also use a directory as a single parameter on the command-line.

Testing

* Tested on Windows only for drag-and-drop. Note that the output is written into the /source/ folder (where the dir being dragged is).
* Tested command line on Windows to make sure it still works as per normal.
* Checked it works with and without trailing slash. e.g.
    * `$ ./vol2obj.exe 1638272406415-rafa/vols/1638272414140_ld/` and
    * `$ ./vol2obj.exe 1638272406415-rafa/vols/1638272414140_ld`

Risk of Merge

* Might not work on macOS/Linux the same way with d&drop - need to test.
* Maybe this is not quite enough to be really useful for all cases - and we want a proper front-end GUI.

* If this is merged we can update the ReadMe - maybe the QuickStart Guide.