### PR TITLE
fix to 1024 texture files not working with drag-and-drop

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ You should be able to import or drag-and-drop this into most 3D software and 3D 
 
 | Tool    | Version | Description                                                                                   |
 |---------|---------|-----------------------------------------------------------------------------------------------|
-| vol2obj | 0.5.0   | Convert a frame from a vologram sequence to a Wavefront .obj file + .mtl material + jpg file. |
+| vol2obj | 0.6.0   | Convert a frame from a vologram sequence to a Wavefront .obj file + .mtl material + jpg file. |
 | cutvols | 0.3.0   | Cut a sequence of frames from a vologram into a new, shorter, vologram sequence.              |
 
 Further tools to be added: obj2vol, sequence cutting and manipulation. 


### PR DESCRIPTION
Reason for PR

* Volu now uses 1024x1024 textures with a new filename, but drag-and-drop functionality on Windows was hard-coded to look for the old 2048x2048 filename.
* This caused those conversions to fail to export a texture file. https://github.com/Volograms/vol_cl_tools/issues/20

Changes in PR

* For cases where a vologram contained multiple videos, the tool still tries to find the 2048 video first, but failing that, it falls back to look for the 1024 video texture.

Testing Done

* Tested this with drag-and-drop of both 1024 and 2048 video texture vologram folders, as well as one with both resolutions, on Windows (drag and drop only works on windows).
* I also ran the equivalent on the command-line: `./vol2obj.exe MYFOLDERHERE` to confirm this worked from the command-line (this will work on all systems) without errors.

Risk of Merging PR

* We don't have any CI/CD or coverage tests set up for this tool but it's on the TODO list.
* This tools is not, to my knowledge, integrated in any pipeline yet so very minimal risk of breaking changes.

Notes

* I found a weird bug in Windows 3D Viewer when testing this (see the linked issue ticket).