### PR TITLE
user file prefix [WIP]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,8 @@ output_frame_*
 *.dll
 vol_cl_tools_*
 build/
+
+*.jpg
+*.mtl
+*.webp
+*.png

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 CC          = clang
 # -Werror is useful when upgrading the API as it upgrades deprecation warnings to errors.
 FLAGS       = -std=c99 -m64 -Wfatal-errors -pedantic -Wextra -Wall
-#DEBUG       = -g -DVOL_AV_DEBUG -DVOL_GEOM_DEBUG
+DEBUG       = -g -DVOL_AV_DEBUG -DVOL_GEOM_DEBUG
 #SANS        = -fsanitize=address -fsanitize=undefined 
 INC_DIR     = -I lib/ -I thirdparty/
 SRC_AV      = lib/vol_av.c


### PR DESCRIPTION
## Purpose of this PR

* This is a user-requested feature for vol2obj command line tool that allows a user to specify the output filename prefix, in place of the default `output_frame_`.
* The new flag `--prefix` or `-p` followed by a string of characters, without spaces, will be used as the prefix. This can help differentiate between multiple outputs written to the same folder.
* Internal code VOLUAPP-1083.

## Changes made in this PR

Write a summary here describing **_what_** work you did in your branch, and **_how_** you did it (explain your approach).

* Added a new flag to specify prefix.
* Also made sure all the command line flags had both `-p` single and `--prefix` word options, including mandatory flags `-h` `--header`, `-s` `--sequence`, and `-v` `--video`.
* Try to attach **screenshots** wherever possible - a picture is worth 1000 words.
* An attached video, or gif, may be worth even more.
* Did you update any unit tests or automated tests to cover your changes e.g. scripts run in GitHub Actions?
* Did you update the docs to cover new interface code? This could be function interface comments, or external documentation, as project-appropriate.
* Did you update comments in code to explain difficult-to-read sections?

## Testing Summary

Provide more detail here as required.

- [x] Explained how reviewers build, deploy, and test your code and what should they look for that would indicate a bug or regression.

* Pull, `make`, `./vol2obj.bin` or `.\vol2obj.exe` and the new flag is `--prefix` or `-p`.
* Other new flags are `--header`, `--sequence`, `--video`, `-d`.
* I changed the output of the `--help` command to reflect this.

- [x] Tested locally. Which platforms? OS/hardware/devices/compilers used.

* Ubuntu + GCC 11.2.

- [x] Stated supported platforms have you not tested on, that you need help with?

* I cannot test on macOS and need a hand here.
* I still need to test on Windows.

- [x] Named specific tools have you ran over the code: e.g. which { compilers, debuggers, fuzzers, profilers, sanitisers, linters, other tools }.

* Just GCC with `-Wall -Wextra -pedantic`.
* Recompiled with Asan just now, and found the following issues:

```
tools/vol2obj/main.c:244:17: runtime error: load of misaligned address 0x7f126b4ad80d for type 'const float', which requires 4 byte alignment
0x7f126b4ad80d: note: pointer points here
 10 8e 01 00 6c 7b 6b  3f b0 8f c2 3f 53 b2 1c  3e 07 99 6c 3f ed bb c2  3f ff cd 1b 3e b6 84 6c  3f
```

* Same issue on lines 244,245,246,253,254,261,262,263,279,280.281.
* UBSan found: `UndefinedBehaviorSanitizer: undefined-behavior tools/vol2obj/main.c:281:22`
* UBSan + ASan found known issues in library stb_image_write.
* Will investigate before inviting reviewers.

- [x] Explained inputs used to test for bugs. e.g. existing known working data, large files, empty files, etc.

* Tested with rafa t-pose, russ, ulysses 8GB hd. All produced correct (and correctly named) output that loaded into Blender.
* Tested with combinations of new and old flags.
* Tested with no and malformed flags (help menu)
* Tested with no prefix to see if the default still worked.

## Risk Introduced and any Breaking Changes

- [x] Gaps in testing: Are you unable to test on some platform? Or is some input data not available to you for testing?

* Anyone testing with any additional volograms that are known to work before would be helpful.

- [x] Analysed any other potential risks here.

* I have not made any assumptions about the validity of input characters, so it may be possible to produce invalid, or hidden, files on some operating systems if characters such as `?*/\.` are used. I could check for these (and add that to this PR), but this might cause problems if input text is not ASCII but e.g. UTF-8 or UTF-16 and second or third bytes in a codepoint are interpreted as individual ASCII characters.

## Pre-Merge Checklist

* If you have a problem with the review process (e.g. it's taking too long, or the reviewers forgot) get in touch with the Team Lead of the project!

- [ ] Before making your PR, refresh your branch with a merge from its parent in case of conflicting changes since you started your branch.
- [ ] This PR description is written clearly so that reviewers can understand the why/what/how of the work done.
- [ ] Reviewed your own PR and checked your changed code.
- [ ] Invited a range of good reviewers.
- [ ] Wait for a PR to be properly reviewed. Responded to all questions, and made any required changes.
- [ ] Received one other reviewer's approval. Ideally wait for 2+ approvals, especially if you didn't get a thorough reivew on the first approval.
- [ ] If a reviewer asks a question, even if you have another approval, got the approval of the other reviewers as well before merging.
- [ ] Made sure existing reviewers approved any changes to the PR.
- [ ] Resolved any merge conflicts after making the PR.
- [ ] CI/CD builds are not reporting any errors.
