### PR TITLE
28 vols files without normals fail obj conversion

### DIFF
--- a/tools/vol2obj/main.c
+++ b/tools/vol2obj/main.c
@@ -374,7 +374,7 @@ static bool _write_mesh_to_obj_file( const char* output_mesh_filename, const cha
       fprintf( f_ptr, "vt %0.3f %0.3f\n", s, t );
     }
   }
-  assert( normals_ptr && "Hey if there are no normals Anton should make sure that is accounted for in the f section" );
+  // assert( normals_ptr && "Hey if there are no normals Anton should make sure that is accounted for in the f section" );
   if ( normals_ptr ) {
     for ( int i = 0; i < n_normals; i++ ) {
       float x = normals_ptr[i * 3 + 0];

--- a/tools/vol2obj/main.c
+++ b/tools/vol2obj/main.c
@@ -400,7 +400,11 @@ static bool _write_mesh_to_obj_file( const char* output_mesh_filename, const cha
       int b = (int)( i_u16_ptr[i * 3 + 1] ) + 1;
       int c = (int)( i_u16_ptr[i * 3 + 2] ) + 1;
       // NOTE(Anton) VOLS winding order is CW (similar to Unity) rather than typical CCW so let's reverse it for OBJ
-      fprintf( f_ptr, "f %i/%i/%i %i/%i/%i %i/%i/%i\n", c, c, c, b, b, b, a, a, a );
+      if ( normals_ptr ) {
+        fprintf( f_ptr, "f %i/%i/%i %i/%i/%i %i/%i/%i\n", c, c, c, b, b, b, a, a, a ); // f v1/vt1/vn1 v2/vt2/vn2 v3/vt3/vn3 ...
+      } else {
+        fprintf( f_ptr, "f %i/%i %i/%i %i/%i\n", c, c, b, b, a, a );                   // f v1/vt1 v2/vt2 v3/vt3 ...
+      }
     }
   }
 


### PR DESCRIPTION
## Purpose of this PR

Normals inside vols file are optional and the conversion into OBJ files was failing when normals were not included.

## Changes made in this PR

* removed assert that checked normals data and failed conversion if it was null
* updated triangle output for OBJ file to include both options, with and without normals

## Testing Summary

This change was tested locally on Windows
* using an older sequence encoded without normals and the conversion finished successfully.  
* using a sequence encoded with normals and the conversion finished successfully as well.  

## Risk Introduced and any Breaking Changes

There are no breaking changes in  this PR. 

## Pre-Merge Checklist

* If you have a problem with the review process (e.g. it's taking too long, or the reviewers forgot) get in touch with the Team Lead of the project!

- [x] Before making your PR, refresh your branch with a merge from its parent in case of conflicting changes since you started your branch.
- [ ] This PR description is written clearly so that reviewers can understand the why/what/how of the work done.
- [x] Reviewed your own PR and checked your changed code.
- [x] Invited a range of good reviewers.
- [ ] Wait for a PR to be properly reviewed. Responded to all questions, and made any required changes.
- [ ] Received one other reviewer's approval. Ideally wait for 2+ approvals, especially if you didn't get a thorough reivew on the first approval.
- [ ] If a reviewer asks a question, even if you have another approval, got the approval of the other reviewers as well before merging.
- [ ] Made sure existing reviewers approved any changes to the PR.
- [ ] Resolved any merge conflicts after making the PR.
- [ ] CI/CD builds are not reporting any errors.
